### PR TITLE
Refactor home page to use Suspense streaming for stats

### DIFF
--- a/src/app/(app)/(public)/page.tsx
+++ b/src/app/(app)/(public)/page.tsx
@@ -1,9 +1,13 @@
 import Link from "next/link";
-import { getAllJobs, getAllUsers } from "@/db/queries";
+import { Suspense } from "react";
 import { ArrowDown, HeartHandshake, MoveRight } from "lucide-react";
 
 import Container from "@components/Container";
 import HomePageReviewCarousel from "@components/HomePageReviewCarousel";
+import {
+  HomePageStats,
+  HomePageStatsSkeleton,
+} from "@components/HomePageStats";
 import ServicesContent from "@components/ServicesContent";
 import H1 from "@components/typography/h1";
 import H2 from "@components/typography/h2";
@@ -11,14 +15,7 @@ import { Button } from "@components/ui/button";
 import { Card, CardContent, CardFooter } from "@components/ui/card";
 import InteractiveButton from "@components/ui/InteractiveButton";
 
-export const dynamic = "force-dynamic";
-
-export default async function Home() {
-  const jobs = await getAllJobs();
-  const jobsCount = jobs.length;
-  const users = await getAllUsers();
-  const usersCount = users.length;
-
+export default function Home() {
   return (
     <main className="flex w-full flex-col items-center justify-center">
       <Container
@@ -66,26 +63,9 @@ export default async function Home() {
       </Container>
       <Container className="from-tertiary to-background flex w-full flex-col items-center justify-center gap-6 bg-gradient-to-tr to-50% py-20">
         <div className="flex w-full flex-col items-center justify-center gap-32">
-          <div className="mt-8 flex w-full flex-col justify-center gap-8 sm:flex-row sm:gap-8 md:gap-16 lg:gap-24">
-            <div className="flex flex-col items-center gap-2 text-center">
-              <H2 className="xs:text-6xl text-5xl sm:text-6xl">
-                {810 + jobsCount}
-                <span className="text-primary">+</span>
-              </H2>
-              <p className="text-accent-foreground text-lg font-semibold underline underline-offset-8">
-                Jobs requested and completed
-              </p>
-            </div>
-            <div className="flex flex-col items-center gap-2 text-center">
-              <H2 className="xs:text-6xl text-5xl sm:text-6xl">
-                {240 + usersCount}
-                <span className="text-primary">+</span>
-              </H2>
-              <p className="text-accent-foreground text-lg font-semibold underline underline-offset-8">
-                Parents, kids, and families served
-              </p>
-            </div>
-          </div>
+          <Suspense fallback={<HomePageStatsSkeleton />}>
+            <HomePageStats />
+          </Suspense>
           <div className="flex w-full flex-col items-center gap-8">
             <H2 className="xs:text-3xl text-center text-3xl md:text-4xl">
               <span className="">Trusted</span> by the{" "}

--- a/src/components/HomePageStats.tsx
+++ b/src/components/HomePageStats.tsx
@@ -1,0 +1,51 @@
+import { getAllJobs, getAllUsers } from "@/db/queries";
+
+import H2 from "@components/typography/h2";
+
+export async function HomePageStats() {
+  const [jobs, users] = await Promise.all([getAllJobs(), getAllUsers()]);
+  const jobsCount = jobs.length;
+  const usersCount = users.length;
+
+  return (
+    <div className="mt-8 flex w-full flex-col justify-center gap-8 sm:flex-row sm:gap-8 md:gap-16 lg:gap-24">
+      <div className="flex flex-col items-center gap-2 text-center">
+        <H2 className="xs:text-6xl text-5xl sm:text-6xl">
+          {810 + jobsCount}
+          <span className="text-primary">+</span>
+        </H2>
+        <p className="text-accent-foreground text-lg font-semibold underline underline-offset-8">
+          Jobs requested and completed
+        </p>
+      </div>
+      <div className="flex flex-col items-center gap-2 text-center">
+        <H2 className="xs:text-6xl text-5xl sm:text-6xl">
+          {240 + usersCount}
+          <span className="text-primary">+</span>
+        </H2>
+        <p className="text-accent-foreground text-lg font-semibold underline underline-offset-8">
+          Parents, kids, and families served
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function HomePageStatsSkeleton() {
+  return (
+    <div className="mt-8 flex w-full flex-col justify-center gap-8 sm:flex-row sm:gap-8 md:gap-16 lg:gap-24">
+      <div className="flex flex-col items-center gap-2 text-center">
+        <div className="bg-muted xs:h-16 xs:w-32 h-14 w-28 animate-pulse rounded-md sm:h-16 sm:w-32" />
+        <p className="text-accent-foreground text-lg font-semibold underline underline-offset-8">
+          Jobs requested and completed
+        </p>
+      </div>
+      <div className="flex flex-col items-center gap-2 text-center">
+        <div className="bg-muted xs:h-16 xs:w-32 h-14 w-28 animate-pulse rounded-md sm:h-16 sm:w-32" />
+        <p className="text-accent-foreground text-lg font-semibold underline underline-offset-8">
+          Parents, kids, and families served
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Replace `force-dynamic` with React Suspense streaming for better UX
- Page shell renders instantly, stats stream in when database responds
- Follows Next.js recommended patterns for data fetching

## Changes

- Extract `HomePageStats` as async Server Component that fetches data
- Add `HomePageStatsSkeleton` with animated pulse loading state
- Wrap stats in `<Suspense>` boundary with skeleton fallback
- Remove `force-dynamic` export - no longer needed

## Test Plan

- [ ] Build completes without timeout errors on Vercel
- [ ] Home page loads instantly with skeleton in stats area
- [ ] Stats populate when database query completes
- [ ] Skeleton matches stats layout to prevent layout shift